### PR TITLE
Clarify documentation for L-test defaults

### DIFF
--- a/ltest.py
+++ b/ltest.py
@@ -35,7 +35,7 @@ Created on Wed Sep 24 16:34:33 2025
         Sample 1 (must have n ≥ 2).
     y : array_like, shape (m,)
         Sample 2 (must have m ≥ 2).
-    B : int, optional (default=500)
+    B : int, optional (default=5000)
         Maximum number of bootstrap/permutation replicates used to estimate the
         L-test p-value. Early stopping may terminate before B if the relative
         Monte Carlo uncertainty target is met.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -78,7 +78,7 @@ def test_shift_invariance_global_additive():
 
     _finite_tuple(res1); _finite_tuple(res2)
 
-    # l_stat and cvm_p should be close (shift-invariant)
+    # l_stat and l_p should be close (shift-invariant)
     assert abs(res1[5] - res2[5]) < 0.01  # l_stat
     assert abs(res1[0] - res2[0]) < 3e-3  # l_p
 


### PR DESCRIPTION
## Summary
- correct the documented default B value in `ltest.ltest` to match the implementation
- update a test comment to reference the L-test p-value instead of an obsolete CvM name

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'ltest')*


------
https://chatgpt.com/codex/tasks/task_e_68e5d4952e30832a98fde0d2fb831f82